### PR TITLE
Correct promise testing.

### DIFF
--- a/spec/example.spec.js
+++ b/spec/example.spec.js
@@ -32,6 +32,6 @@ describe('Async', function () {
 
 describe('Promise', function () {
   it('is true', function () {
-    expect(example.promise(true)).to.eventually.be.true;
+    return expect(example.promise(true)).to.eventually.be.true;
   });
 });


### PR DESCRIPTION
Revert change that broke testing promises:
it function must return expect expression