### PR TITLE
Install and configure grunt nodemon

### DIFF
--- a/grunt/nodemon.json
+++ b/grunt/nodemon.json
@@ -1,0 +1,3 @@
+{
+  "script": "bin/example.js"
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ga-wdi-boston.node-template",
   "version": "0.0.1",
   "private": true,
-  "scripts":{
+  "scripts": {
     "start": "node bin/example.js"
   },
   "license": {


### PR DESCRIPTION
For #10 

@ga-wdi-boston/core @gaand Do you have a preference for whether the starting command should be `grunt nodemon`, `grunt`, `grunt server`, `grunt start`, or `npm start`?